### PR TITLE
Make root URL redirect to icu crate, not icu4x crate

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0;url=./doc/icu4x" />
+    <meta http-equiv="refresh" content="0;url=./doc/icu" />
     <title>ICU4X Developer Docs</title>
   </head>
   <body>
-    <p><a href="./doc/icu4x">Redirect to icu4x crate doc</a></p>
+    <p><a href="./doc/icu">Redirect to the <tt>icu</tt> crate of ICU4X</a></p>
   </body>
 </html>


### PR DESCRIPTION
Trying to fix the default behavior for when users hit the link https://unicode-org.github.io/icu4x-docs/

We may have switched the primary crate early on from the `icu4x` crate to the `icu` crate, and then didn't switch this accordingly.