### PR TITLE
Improvements to icu4x-convert: --overwrite and --outputScriptPath

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig({
 						'principles'
 					],
 				},
+				// DO NOT DELETE: INSERT NEW VERSIONS HERE
 				{
 					label: 'Version 2.2',
 					badge: {

--- a/tools/github-to-astro.ts
+++ b/tools/github-to-astro.ts
@@ -1,9 +1,6 @@
 import fs from 'node:fs';
 import { parseArgs } from "node:util";
 import path from 'node:path';
-import { dir } from 'node:console';
-import { get } from 'node:https';
-import { release } from 'node:os';
 
 // Hard code the tutorial names that are not version specific,
 // So that they are not being transformed by this script
@@ -200,9 +197,9 @@ function printHelp() {
   console.log("Convert ICU4X Github repo Markdown tutorials to Astro MDX files");
   console.log();
   console.log("Usage:");
-  console.log("\tnpm run icu4x-convert -- --icu4xDir=<input-dir> --icu4xVersion=<minor version> [--icu4xRef=<ICU4X-git-ref>] [--sitePrefix=<site-prefix-str-else-emptystr>] [--overwrite]");
+  console.log("\tnpm run icu4x-convert -- --icu4xDir=<input-dir> --icu4xVersion=<minor version> [--icu4xRef=<ICU4X-git-ref>] [--sitePrefix=<site-prefix-str-else-emptystr>] [--overwrite] [--outputScriptPath=<path>]");
   console.log();
-  console.log("Example: npm run icu4x-convert -- --icu4xDir=../path/to/icu4x/ --icu4xVersion=2.1 [--icu4xRef=release/2.1-draft] [--sitePrefix=/uriPrefix] [--overwrite]")
+  console.log("Example: npm run icu4x-convert -- --icu4xDir=../path/to/icu4x/ --icu4xVersion=2.1 [--icu4xRef=release/2.1-draft] [--sitePrefix=/uriPrefix] [--overwrite] [--outputScriptPath=build-artifacts.sh]")
 }
 
 /**
@@ -231,6 +228,9 @@ function parseCLIArgs() {
         type: "boolean",
         default: false,
       },
+      outputScriptPath: {
+        type: "string",
+      },
     }
   });
   let {values, positionals} = parsedArgs;
@@ -245,6 +245,7 @@ function parseCLIArgs() {
                                                  // URIs for base site icu4x.unicode.org do not need
                                                  // a prefix, unlike hosting on Github Pages
         overwrite: values["overwrite"] ?? false,
+        outputScriptPath: values["outputScriptPath"],
       }
     };
 
@@ -274,6 +275,7 @@ try {
   const icu4xRef = values["icu4xRef"];
   const sitePrefix = values["sitePrefix"];
   const overwrite = values["overwrite"];
+  const outputScriptPath = values["outputScriptPath"];
   const webDirName = icu4xVersion.replace('.', '_');
   const artifactsDir = path.join(root, 'public', webDirName);
   const outputDirPath = path.join(root, 'src/content/docs', webDirName);
@@ -366,13 +368,33 @@ try {
     console.log();
   }
 
+  const commands = [
+    `mkdir -p ${artifactsDir}`,
+    `pushd ${icu4xDir} && doxygen tools/doxygen/config.doxy && mv tools/doxygen/html/ ${artifactsDir}/cppdoc; popd`,
+    `pushd ${icu4xDir}/ffi/npm && make lib/index.mjs && typedoc --out ${artifactsDir}/tsdoc; popd`,
+    `pushd ${icu4xDir}/tools/web-demo && npm install && npm run build && mkdir -p ${artifactsDir}/wasmdemo && cp -r public/ ${artifactsDir}/wasmdemo; popd`,
+  ];
+
+  const scriptContent = `#!/usr/bin/env bash
+set -euo pipefail
+
+${commands.join('\n')}
+`;
+
+  if (outputScriptPath) {
+    const resolvedScriptPath = path.resolve(process.cwd(), outputScriptPath);
+    fs.writeFileSync(resolvedScriptPath, scriptContent, { encoding: 'utf8', mode: 0o755 });
+    fs.chmodSync(resolvedScriptPath, 0o755);
+    console.log(`Saved artifact generation commands to ${resolvedScriptPath}`);
+    console.log();
+  }
+
   console.log(`Task: Make sure to dump artifacts in ${artifactsDir}:`);
   console.log("You will need dart, typedoc, doxygen, doxygen-awesomecss installed")
   console.log();
-  console.log(`mkdir ${artifactsDir}`);
-  console.log(`pushd ${icu4xDir} && doxygen tools/doxygen/config.doxy && mv tools/doxygen/html/ ${artifactsDir}/cppdoc; popd`);
-  console.log(`pushd ${icu4xDir}/ffi/npm && make lib/index.mjs && typedoc --out ${artifactsDir}/tsdoc; popd`);
-  console.log(`pushd ${icu4xDir}/tools/web-demo && npm install && npm run build && mkdir ${artifactsDir}/wasmdemo && cp -r public/ ${artifactsDir}/wasmdemo; popd`);
+  for (const cmd of commands) {
+    console.log(cmd);
+  }
 
 } catch (error: unknown) {
   if (error instanceof Error) {

--- a/tools/github-to-astro.ts
+++ b/tools/github-to-astro.ts
@@ -200,9 +200,9 @@ function printHelp() {
   console.log("Convert ICU4X Github repo Markdown tutorials to Astro MDX files");
   console.log();
   console.log("Usage:");
-  console.log("\tnpm run icu4x-convert -- --icu4xDir=<input-dir> --icu4xVersion=<minor version> [--icu4xRef=<ICU4X-git-ref>] [--sitePrefix=<site-prefix-str-else-emptystr>]");
+  console.log("\tnpm run icu4x-convert -- --icu4xDir=<input-dir> --icu4xVersion=<minor version> [--icu4xRef=<ICU4X-git-ref>] [--sitePrefix=<site-prefix-str-else-emptystr>] [--overwrite]");
   console.log();
-  console.log("Example: npm run icu4x-convert -- --icu4xDir=../path/to/icu4x/ --icu4xVersion=2.1 [--icu4xRef=release/2.1-draft] [--sitePrefix=/uriPrefix]")
+  console.log("Example: npm run icu4x-convert -- --icu4xDir=../path/to/icu4x/ --icu4xVersion=2.1 [--icu4xRef=release/2.1-draft] [--sitePrefix=/uriPrefix] [--overwrite]")
 }
 
 /**
@@ -227,6 +227,10 @@ function parseCLIArgs() {
       sitePrefix: {
         type: "string",
       },
+      overwrite: {
+        type: "boolean",
+        default: false,
+      },
     }
   });
   let {values, positionals} = parsedArgs;
@@ -240,6 +244,7 @@ function parseCLIArgs() {
         sitePrefix: values["sitePrefix"] ?? "",  // default value for sitePrefix is "" because
                                                  // URIs for base site icu4x.unicode.org do not need
                                                  // a prefix, unlike hosting on Github Pages
+        overwrite: values["overwrite"] ?? false,
       }
     };
 
@@ -268,6 +273,7 @@ try {
   const icu4xVersion = values["icu4xVersion"];
   const icu4xRef = values["icu4xRef"];
   const sitePrefix = values["sitePrefix"];
+  const overwrite = values["overwrite"];
   const webDirName = icu4xVersion.replace('.', '_');
   const artifactsDir = path.join(root, 'public', webDirName);
   const outputDirPath = path.join(root, 'src/content/docs', webDirName);
@@ -279,66 +285,86 @@ try {
   console.log("Markdown conversion finished successfully");
   console.log();
 
-  console.log(
-    `{
-    label: 'Version ${icu4xVersion}',
-    badge: {
-      text: 'New',
-      variant: 'success',
-    },
-    items: [
-      {
-        label: 'Code examples',
-        link: 'https://github.com/unicode-org/icu4x/tree/${icu4xRef}/examples',
-        badge: { text: '↗', variant: 'tip' },
-        attrs: { target: '_blank' },
-      },
-      {
-        label: 'Interactive Demo',
-        slug: '${webDirName}/demo',
-      },
-      {
-        label: 'API documentation',
-        items: [
-          {
-            label: 'Rust',
-            link: 'https://docs.rs/icu/${icu4xVersion}',
-            badge: { text: '↗', variant: 'tip' },
-            attrs: { target: '_blank' },
+  const versionConfigSnippet = `{
+					label: 'Version ${icu4xVersion}',
+					badge: {
+						text: 'New',
+						variant: 'success',
+					},
+					items: [
+						{
+							label: 'Code examples',
+							link: 'https://github.com/unicode-org/icu4x/tree/${icu4xRef}/examples',
+							badge: { text: '↗', variant: 'tip' },
+							attrs: { target: '_blank' },
+						},
+						{
+							label: 'Interactive Demo',
+							slug: '${webDirName}/demo',
+						},
+						{
+							label: 'API documentation',
+							items: [
+								{
+									label: 'Rust',
+									link: 'https://docs.rs/icu/${icu4xVersion}',
+									badge: { text: '↗', variant: 'tip' },
+									attrs: { target: '_blank' },
+								},
+								{
+									label: 'C++',
+									link: '/${webDirName}/cppdoc/',
+									badge: { text: '↗', variant: 'tip' },
+									attrs: { target: '_blank' },
+								},
+								{
+									label: 'Dart',
+									link: 'https://pub.dev/documentation/icu4x/${icu4xVersion}/',
+									badge: { text: '↗', variant: 'tip' },
+									attrs: { target: '_blank' },
+								},
+								{
+									label: 'TypeScript',
+									link: '/${webDirName}/tsdoc/',
+									badge: { text: '↗', variant: 'tip' },
+									attrs: { target: '_blank' },
+								},
+							],
+						},
+						{
+							label: 'Tutorials',
+							autogenerate: { directory: '${webDirName}/tutorials' },
+						},
+					],
+					collapsed: latest_dir_name != '${webDirName}',
+				},`;
 
-          },
-          {
-            label: 'C++',
-            link: '/${webDirName}/cppdoc/',
-            badge: { text: '↗', variant: 'tip' },
-            attrs: { target: '_blank' },
-          },
-          {
-            label: 'Dart',
-            link: 'https://pub.dev/documentation/icu4x/${icu4xVersion}/',
-            badge: { text: '↗', variant: 'tip' },
-            attrs: { target: '_blank' },
-          },
-          {
-            label: 'TypeScript',
-            link: '/${webDirName}/tsdoc/',
-            badge: { text: '↗', variant: 'tip' },
-            attrs: { target: '_blank' },
-          },
-        ],
-      },
-      {
-        label: 'Tutorials',
-        autogenerate: { directory: '${webDirName}/tutorials' },
-      },
-    ],
-    collapsed: latest_dir_name != '${webDirName}',
-  },
-    `
-  );
+  if (overwrite) {
+    const astroConfigPath = path.join(root, 'astro.config.mjs');
+    let configContent = fs.readFileSync(astroConfigPath, { encoding: 'utf8' });
+    const marker = '// DO NOT DELETE: INSERT NEW VERSIONS HERE';
+    
+    if (!configContent.includes(marker)) {
+      console.error(`Error: Could not find marker "${marker}" in astro.config.mjs`);
+      process.exit(1);
+    }
 
-  console.log("Task: Add the above JSON to astro.config.mjs if it doesn't exist yet");
-  console.log();
+    configContent = configContent.replace(
+      /const latest_version = '.*?';/,
+      `const latest_version = '${icu4xVersion}';`
+    );
+
+    const replacement = `${marker}\n\t\t\t\t${versionConfigSnippet.trim()}`;
+    configContent = configContent.replace(marker, replacement);
+
+    fs.writeFileSync(astroConfigPath, configContent, { encoding: 'utf8' });
+    console.log("Updated astro.config.mjs with new version configuration.");
+    console.log();
+  } else {
+    console.log(versionConfigSnippet);
+    console.log("Task: Add the above JSON to astro.config.mjs if it doesn't exist yet");
+    console.log();
+  }
 
   console.log(`Task: Make sure to dump artifacts in ${artifactsDir}:`);
   console.log("You will need dart, typedoc, doxygen, doxygen-awesomecss installed")


### PR DESCRIPTION
Improvements to the `icu4x-convert` tool (`tools/github-to-astro.ts`):

1. **`--overwrite` flag**: Update `astro.config.mjs` directly with new version configuration using a marker comment.
2. **`--outputScriptPath` flag**: Save the generated artifact dump commands into an executable shell script (`chmod +x`).
3. Remove unused CLI options and imports.

🤖 This pull request was updated by an AI agent working with @sffc.